### PR TITLE
Remove period for consistency

### DIFF
--- a/source/includes/examples-index-base.yaml
+++ b/source/includes/examples-index-base.yaml
@@ -11,7 +11,7 @@ pre: |
   ``restaurants`` collection.
 ---
 title:
-  text: Create a compound index.
+  text: Create a compound index
   level: 2
 ref: _create-compound-index
 pre: |


### PR DESCRIPTION
None of the other titles have a period at the end

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mongodb/docs-primer/3)
<!-- Reviewable:end -->
